### PR TITLE
Update canary nodejs

### DIFF
--- a/ReferenceDataApi/serverless.yml
+++ b/ReferenceDataApi/serverless.yml
@@ -132,7 +132,7 @@ resources:
             - - 'arn:aws:iam:'
               - Ref: 'AWS::AccountId'
               - role/LBH_Canary_Role
-        RuntimeVersion: syn-nodejs-puppeteer-3.1
+        RuntimeVersion: syn-nodejs-puppeteer-9.1
         RunConfig:
           TimeoutInSeconds: 300
           EnvironmentVariables:


### PR DESCRIPTION
Current canary nodejs version is not supported on AWS anymore. Need to upgrade to unblock the pipeline