### PR TITLE
TS-2045 add pre-production workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,114 +256,114 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  # check:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - release
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             ignore:
-  #               - master
-  #               - release
+  check:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              ignore:
+                - master
+                - release
 
-  # check-and-deploy-development:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #             branches:
-  #               only: master
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           - build-and-test
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
-  #     - terraform-apply-development:
-  #         requires:
-  #           - terraform-compliance-development
-  #     - deploy-to-development:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - terraform-apply-development
+  check-and-deploy-development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: master
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+              branches:
+                only: master
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - build-and-test
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+      - terraform-apply-development:
+          requires:
+            - terraform-compliance-development
+      - deploy-to-development:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - terraform-apply-development
 
-  # check-and-deploy-staging-and-production:
-  #   jobs:
-  #     - build-and-test:
-  #         context:
-  #             - api-nuget-token-context
-  #             - SonarCloud
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         requires:
-  #             - build-and-test
-  #     - terraform-init-and-plan-staging:
-  #         requires:
-  #           - assume-role-staging
-  #     - terraform-compliance-staging:
-  #         requires:
-  #           - terraform-init-and-plan-staging
-  #     - terraform-apply-staging:
-  #         requires:
-  #           - terraform-compliance-staging
-  #     - deploy-to-staging:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - terraform-apply-staging
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #     - assume-role-production:
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #             - permit-production-terraform-release
-  #     - terraform-init-and-plan-production:
-  #         requires:
-  #           - assume-role-production
-  #     - terraform-compliance-production:
-  #         requires:
-  #           - terraform-init-and-plan-production
-  #     - terraform-apply-production:
-  #         requires:
-  #           - terraform-compliance-production
-  #     - permit-production-release:
-  #         type: approval
-  #         requires:
-  #           - terraform-apply-production
-  #     - deploy-to-production:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - permit-production-release
+  check-and-deploy-staging-and-production:
+    jobs:
+      - build-and-test:
+          context:
+              - api-nuget-token-context
+              - SonarCloud
+          filters:
+            branches:
+              only: release
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+              - build-and-test
+      - terraform-init-and-plan-staging:
+          requires:
+            - assume-role-staging
+      - terraform-compliance-staging:
+          requires:
+            - terraform-init-and-plan-staging
+      - terraform-apply-staging:
+          requires:
+            - terraform-compliance-staging
+      - deploy-to-staging:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - terraform-apply-staging
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-terraform-release
+      - terraform-init-and-plan-production:
+          requires:
+            - assume-role-production
+      - terraform-compliance-production:
+          requires:
+            - terraform-init-and-plan-production
+      - terraform-apply-production:
+          requires:
+            - terraform-compliance-production
+      - permit-production-release:
+          type: approval
+          requires:
+            - terraform-apply-production
+      - deploy-to-production:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - permit-production-release
 
   deploy-terraform-pre-production:
     jobs:
@@ -371,63 +371,56 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - permit-pre-production-terraform-workflow
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-init-and-plan-pre-production:
           requires:
             - assume-role-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-compliance-pre-production:
           requires:
             - terraform-init-and-plan-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - permit-pre-production-terraform-deployment:
           type: approval
           requires:
             - terraform-compliance-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-apply-pre-production:
           requires:
             - permit-pre-production-terraform-deployment
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
 
   deploy-code-pre-production:
     jobs:
-      - permit-pre-production-code-workflow:
-          type: approval
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflows
       - build-and-test:
-          requires:
-            - permit-pre-production-code-workflow
           context: 
             - api-nuget-token-context
             - SonarCloud
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
@@ -436,4 +429,4 @@ workflows:
             - assume-role-pre-production        
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,113 +229,211 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "production"
+  assume-role-pre-production:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
+  terraform-init-and-plan-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "pre-production"
+  terraform-compliance-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-compliance:
+          environment: "pre-production"
+  terraform-apply-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
+          environment: "pre-production"
+  deploy-to-pre-production:
+    executor: docker-dotnet
+    steps:
+      - deploy-lambda:
+          stage: "pre-production"
 
 workflows:
-  check:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud
-          filters:
-            branches:
-              ignore:
-                - master
-                - release
+  # check:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - release
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             ignore:
+  #               - master
+  #               - release
 
-  check-and-deploy-development:
+  # check-and-deploy-development:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #             branches:
+  #               only: master
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           - build-and-test
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
+  #     - terraform-apply-development:
+  #         requires:
+  #           - terraform-compliance-development
+  #     - deploy-to-development:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - terraform-apply-development
+
+  # check-and-deploy-staging-and-production:
+  #   jobs:
+  #     - build-and-test:
+  #         context:
+  #             - api-nuget-token-context
+  #             - SonarCloud
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         requires:
+  #             - build-and-test
+  #     - terraform-init-and-plan-staging:
+  #         requires:
+  #           - assume-role-staging
+  #     - terraform-compliance-staging:
+  #         requires:
+  #           - terraform-init-and-plan-staging
+  #     - terraform-apply-staging:
+  #         requires:
+  #           - terraform-compliance-staging
+  #     - deploy-to-staging:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - terraform-apply-staging
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #     - assume-role-production:
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #             - permit-production-terraform-release
+  #     - terraform-init-and-plan-production:
+  #         requires:
+  #           - assume-role-production
+  #     - terraform-compliance-production:
+  #         requires:
+  #           - terraform-init-and-plan-production
+  #     - terraform-apply-production:
+  #         requires:
+  #           - terraform-compliance-production
+  #     - permit-production-release:
+  #         type: approval
+  #         requires:
+  #           - terraform-apply-production
+  #     - deploy-to-production:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - permit-production-release
+
+  deploy-terraform-pre-production:
     jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
+      - permit-pre-production-terraform-workflow:
+          type: approval
           filters:
             branches:
-              only: master
+              only: ts-2045-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - permit-pre-production-terraform-workflow
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-init-and-plan-pre-production:
+          requires:
+            - assume-role-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-compliance-pre-production:
+          requires:
+            - terraform-init-and-plan-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - permit-pre-production-terraform-deployment:
+          type: approval
+          requires:
+            - terraform-compliance-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-apply-pre-production:
+          requires:
+            - permit-pre-production-terraform-deployment
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+
+  deploy-code-pre-production:
+    jobs:
+      - permit-pre-production-code-workflow:
+          type: approval
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
       - build-and-test:
-          context:
+          requires:
+            - permit-pre-production-code-workflow
+          context: 
             - api-nuget-token-context
             - SonarCloud
           filters:
-              branches:
-                only: master
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
-      - terraform-apply-development:
-          requires:
-            - terraform-compliance-development
-      - deploy-to-development:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - terraform-apply-development
-
-  check-and-deploy-staging-and-production:
-    jobs:
-      - build-and-test:
-          context:
-              - api-nuget-token-context
-              - SonarCloud
           filters:
             branches:
-              only: release
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          requires:
-              - build-and-test
-      - terraform-init-and-plan-staging:
-          requires:
-            - assume-role-staging
-      - terraform-compliance-staging:
-          requires:
-            - terraform-init-and-plan-staging
-      - terraform-apply-staging:
-          requires:
-            - terraform-compliance-staging
-      - deploy-to-staging:
+              only: ts-2045-add-pre-production-workflows
+      - deploy-to-pre-production:
           context:
-            - api-nuget-token-context
-            - "Serverless Framework"
+          - api-nuget-token-context
+          - "Serverless Framework"
           requires:
-            - terraform-apply-staging
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          requires:
-              - permit-production-terraform-release
-      - terraform-init-and-plan-production:
-          requires:
-            - assume-role-production
-      - terraform-compliance-production:
-          requires:
-            - terraform-init-and-plan-production
-      - terraform-apply-production:
-          requires:
-            - terraform-compliance-production
-      - permit-production-release:
-          type: approval
-          requires:
-            - terraform-apply-production
-      - deploy-to-production:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - permit-production-release
+            - assume-role-pre-production        
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows

--- a/ReferenceDataApi/serverless.yml
+++ b/ReferenceDataApi/serverless.yml
@@ -100,15 +100,6 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'log-group:/aws/lambda/*:*:*'
-                - Effect: "Allow"
-                  Action:
-                    - "s3:PutObject"
-                    - "s3:GetObject"
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - "arn:aws:s3:::"
-                        - "Ref": "ServerlessDeploymentBucket"
           - PolicyName: lambdaInvocation
             PolicyDocument:
               Version: '2012-10-17'
@@ -154,6 +145,7 @@ custom:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   safeguards:
     - title: Require authorizer
       safeguard: require-authorizer
@@ -187,3 +179,7 @@ custom:
       subnetIds:
         - subnet-06a697d86a9b6ed01
         - subnet-0beb266003a56ca82
+    pre-production:
+      subnetIds:
+        - subnet-08aa35159a8706faa
+        - subnet-0b848c5b14f841dfb

--- a/terraform/pre-production/aws_ssm_parameter.tf
+++ b/terraform/pre-production/aws_ssm_parameter.tf
@@ -1,0 +1,11 @@
+resource "aws_ssm_parameter" "reference_data_token" {
+  name  = "/housing-tl/pre-production/reference-data-token"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/pre-production/maint.tf
+++ b/terraform/pre-production/maint.tf
@@ -61,7 +61,7 @@ module "elasticsearch_db_pre_production" {
   environment_name    = "pre-production"
   port                = 443
   domain_name         = "reference-data-api-es"
-  subnet_ids          = [tolist(data.aws_subnet_ids.development.ids)[0]]
+  subnet_ids          = [tolist(data.aws_subnet_ids.pre_production.ids)[0]]
   project_name        = "reference-data-api"
   es_version          = "7.8"
   encrypt_at_rest     = "true"

--- a/terraform/pre-production/maint.tf
+++ b/terraform/pre-production/maint.tf
@@ -61,7 +61,7 @@ module "elasticsearch_db_pre_production" {
   environment_name    = "pre-production"
   port                = 443
   domain_name         = "reference-data-api-es"
-  subnet_ids          = data.aws_subnet_ids.pre_production.ids
+  subnet_ids          = [tolist(data.aws_subnet_ids.development.ids)[0]]
   project_name        = "reference-data-api"
   es_version          = "7.8"
   encrypt_at_rest     = "true"

--- a/terraform/pre-production/maint.tf
+++ b/terraform/pre-production/maint.tf
@@ -1,0 +1,81 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      Name              = "reference-data-api-${var.environment_name}"
+      Environment       = var.environment_name
+      terraform-managed = true
+      project_name      = var.project_name
+      Application       = "MTFH Housing Pre-Production"
+      TeamEmail         = "developementteam@hackney.gov.uk"
+      BackupPolicy      = "Dev"
+      Confidentiality   = "Internal"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  esDomain = "https://${module.elasticsearch_db_pre_production.es_endpoint_url}"
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "housing-pre-production-terraform-state"
+    encrypt        = true
+    region         = "eu-west-2"
+    key            = "services/reference-data-api/state"
+    dynamodb_table = "housing-pre-production-terraform-state-lock"
+  }
+}
+
+data "aws_vpc" "pre_production_vpc" {
+  tags = {
+    Name = "housing-pre-prod-pre-prod"
+  }
+}
+
+data "aws_subnet_ids" "pre_production" {
+  vpc_id = data.aws_vpc.pre_production_vpc.id
+  filter {
+    name   = "tag:Type"
+    values = ["private"]
+  }
+}
+
+module "elasticsearch_db_pre_production" {
+  source              = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
+  vpc_id              = data.aws_vpc.pre_production_vpc.id
+  environment_name    = "pre-production"
+  port                = 443
+  domain_name         = "reference-data-api-es"
+  subnet_ids          = data.aws_subnet_ids.pre_production.ids
+  project_name        = "reference-data-api"
+  es_version          = "7.8"
+  encrypt_at_rest     = "true"
+  instance_type       = "t3.small.elasticsearch"
+  instance_count      = "2"
+  ebs_enabled         = "true"
+  ebs_volume_size     = "30"
+  region              = data.aws_region.current.name
+  account_id          = data.aws_caller_identity.current.account_id
+  create_service_role = false
+}
+
+resource "aws_ssm_parameter" "reference_data_elasticsearch_domain" {
+  name  = "/reference-data-api/pre-production/elasticsearch-domain"
+  type  = "String"
+  value = local.esDomain
+}

--- a/terraform/pre-production/terraform-compliance/opensearch.feature
+++ b/terraform/pre-production/terraform-compliance/opensearch.feature
@@ -1,0 +1,25 @@
+Feature: OpenSearch is used to host the ElasticSearch clusters
+  In order to improve security
+  As engineers
+  We'll use ensure our OpenSearch clusters are configured correctly
+
+  Scenario: Ensure it is deployed in a VPC
+    Given I have aws_elasticsearch_domain defined
+    Then it must contain vpc_options
+
+  Scenario: Ensure OpenSearch clusters are encrypted at rest
+    Given I have aws_elasticsearch_domain defined
+    Then it must contain encrypt_at_rest
+    And its enabled property must be true
+
+  Scenario: Ensure minimum instance count is 2
+    Given I have aws_elasticsearch_domain defined
+    Then it must contain cluster_config
+    And it must contain instance_count
+    And its value must be greater and equal to 2
+
+  Scenario: Ensure instance type is small or medium
+    Given I have aws_elasticsearch_domain defined
+    Then it must contain cluster_config
+    And it must contain instance_type
+    And its value must match the "^(t3\.small\.elasticsearch|t3\.medium\.elasticsearch)" regex

--- a/terraform/pre-production/variables.tf
+++ b/terraform/pre-production/variables.tf
@@ -1,0 +1,9 @@
+variable "environment_name" {
+  type    = string
+  default = "pre-prod"
+}
+
+variable "project_name" {
+  type    = string
+  default = "Housing-Pre-Production"
+}


### PR DESCRIPTION
## Link to JIRA ticket

[TS-2045](https://hackney.atlassian.net/browse/TS-2045)

## Describe this PR

### *What is the problem we're trying to solve*

We need to deploy this API to new housing-pre-production account in order to complete the MTFH/TA backend setup in that environment.

### *What changes have we introduced*

1. Add Terraform resources for pre-production. This includes parameter store value dependencies on top of the existing, production based, configuration. Please note the elasticsearch config is similar to dev rather than prod since we are not expecting heavy traffic in this environment
2. Add Terraform and code deployment workflows for pre-production. Terraform workflow requires manual approval to run but the code workflow runs automatically. This ensure pre-production is always in line with production
3. Remove the unnecessary policy that's stopping deployments from working when using Serverless V4 against new accounts. The policy is not required for the Lambda.

Please note the elasticsearch config is similar to dev rather than prod since we are not expecting heavy traffic in this environment.

Also the es module doesn't support custom tags, so default tags have been applied to all resources deployed by this configuration

[TS-2045]: https://hackney.atlassian.net/browse/TS-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ