### PR TITLE
Bump JWT core to `1.87.0` for Cognito support.

### DIFF
--- a/ReferenceDataApi/ReferenceDataApi.csproj
+++ b/ReferenceDataApi/ReferenceDataApi.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />

--- a/ReferenceDataApi/ReferenceDataApi.csproj
+++ b/ReferenceDataApi/ReferenceDataApi.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.2.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />

--- a/ReferenceDataApi/ReferenceDataApi.csproj
+++ b/ReferenceDataApi/ReferenceDataApi.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.2.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />

--- a/ReferenceDataApi/ReferenceDataApi.csproj
+++ b/ReferenceDataApi/ReferenceDataApi.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Middleware" Version="1.30.0" />
-    <PackageReference Include="Hackney.Core.JWT" Version="1.30.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.30.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />

--- a/ReferenceDataApi/Startup.cs
+++ b/ReferenceDataApi/Startup.cs
@@ -138,9 +138,8 @@ namespace ReferenceDataApi
             services.AddLogCallAspect();
             services.ConfigureElasticSearch(Configuration);
             services.AddElasticSearchHealthCheck();
-            // This is actually insane design, but you have to inject this
-            // so that the logging core could log a user email! Unguessable!
-            // Also quite hard to diagnose.
+            // Token factory used by the logging middleware core package
+            // to print user email. Hidden, indirect, implicit dependency
             services.AddTokenFactory();
 
             RegisterGateways(services);

--- a/ReferenceDataApi/Startup.cs
+++ b/ReferenceDataApi/Startup.cs
@@ -138,7 +138,6 @@ namespace ReferenceDataApi
             services.AddLogCallAspect();
             services.ConfigureElasticSearch(Configuration);
             services.AddElasticSearchHealthCheck();
-            services.AddTokenFactory();
 
             RegisterGateways(services);
             RegisterUseCases(services);

--- a/ReferenceDataApi/Startup.cs
+++ b/ReferenceDataApi/Startup.cs
@@ -3,7 +3,6 @@ using Amazon.XRay.Recorder.Core;
 using Amazon.XRay.Recorder.Handlers.AwsSdk;
 using FluentValidation.AspNetCore;
 using Hackney.Core.HealthCheck;
-using Hackney.Core.JWT;
 using Hackney.Core.Logging;
 using Hackney.Core.Middleware.CorrelationId;
 using Hackney.Core.Middleware.Exception;
@@ -138,7 +137,7 @@ namespace ReferenceDataApi
             services.AddLogCallAspect();
             services.ConfigureElasticSearch(Configuration);
             services.AddElasticSearchHealthCheck();
-            services.AddTokenFactory();
+
             RegisterGateways(services);
             RegisterUseCases(services);
         }

--- a/ReferenceDataApi/Startup.cs
+++ b/ReferenceDataApi/Startup.cs
@@ -3,6 +3,7 @@ using Amazon.XRay.Recorder.Core;
 using Amazon.XRay.Recorder.Handlers.AwsSdk;
 using FluentValidation.AspNetCore;
 using Hackney.Core.HealthCheck;
+using Hackney.Core.JWT;
 using Hackney.Core.Logging;
 using Hackney.Core.Middleware.CorrelationId;
 using Hackney.Core.Middleware.Exception;
@@ -137,6 +138,10 @@ namespace ReferenceDataApi
             services.AddLogCallAspect();
             services.ConfigureElasticSearch(Configuration);
             services.AddElasticSearchHealthCheck();
+            // This is actually insane design, but you have to inject this
+            // so that the logging core could log a user email! Unguessable!
+            // Also quite hard to diagnose.
+            services.AddTokenFactory();
 
             RegisterGateways(services);
             RegisterUseCases(services);

--- a/ReferenceDataApi/Startup.cs
+++ b/ReferenceDataApi/Startup.cs
@@ -138,7 +138,7 @@ namespace ReferenceDataApi
             services.AddLogCallAspect();
             services.ConfigureElasticSearch(Configuration);
             services.AddElasticSearchHealthCheck();
-
+            services.AddTokenFactory();
             RegisterGateways(services);
             RegisterUseCases(services);
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: ReferenceDataApi/Dockerfile
       args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
     environment:
       - ElasticSearchDomainUrl=http://reference-data-elasticsearch:9200
     networks:
@@ -23,16 +23,16 @@ services:
       context: .
       dockerfile: ReferenceDataApi.Tests/Dockerfile
       args:
-        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
-        - SONAR_TOKEN=${SONAR_TOKEN}
+      - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+      - SONAR_TOKEN=${SONAR_TOKEN}
     environment:
       - ElasticSearchDomainUrl=http://reference-data-elasticsearch:9200
     networks:
       - elastic
     depends_on:
-      reference-data-elasticsearch:
-        condition: service_healthy
-
+      #- kibana
+      - reference-data-elasticsearch
+      
   reference-data-elasticsearch:
     image: reference-data-elasticsearch
     container_name: reference-data-elasticsearch
@@ -51,12 +51,7 @@ services:
       - reference-data-esdata-test:/usr/share/elasticsearch/data
     networks:
       - elastic
-    healthcheck:
-      test: [ "CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 20s
+
   #kibana:
   #  image: docker.elastic.co/kibana/kibana:7.9.3
   #  ports:
@@ -65,10 +60,10 @@ services:
   #      - elastic
   #  depends_on:
   #      - reference-data-elasticsearch
-
+        
 volumes:
-  reference-data-esdata-test:
-    driver: local
+    reference-data-esdata-test:
+        driver: local
 
 networks:
   elastic:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: ReferenceDataApi/Dockerfile
       args:
-      - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
     environment:
       - ElasticSearchDomainUrl=http://reference-data-elasticsearch:9200
     networks:
@@ -23,16 +23,16 @@ services:
       context: .
       dockerfile: ReferenceDataApi.Tests/Dockerfile
       args:
-      - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
-      - SONAR_TOKEN=${SONAR_TOKEN}
+        - LBHPACKAGESTOKEN=${LBHPACKAGESTOKEN}
+        - SONAR_TOKEN=${SONAR_TOKEN}
     environment:
       - ElasticSearchDomainUrl=http://reference-data-elasticsearch:9200
     networks:
       - elastic
     depends_on:
-      #- kibana
-      - reference-data-elasticsearch
-      
+      reference-data-elasticsearch:
+        condition: service_healthy
+
   reference-data-elasticsearch:
     image: reference-data-elasticsearch
     container_name: reference-data-elasticsearch
@@ -51,7 +51,12 @@ services:
       - reference-data-esdata-test:/usr/share/elasticsearch/data
     networks:
       - elastic
-
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
   #kibana:
   #  image: docker.elastic.co/kibana/kibana:7.9.3
   #  ports:
@@ -60,10 +65,10 @@ services:
   #      - elastic
   #  depends_on:
   #      - reference-data-elasticsearch
-        
+
 volumes:
-    reference-data-esdata-test:
-        driver: local
+  reference-data-esdata-test:
+    driver: local
 
 networks:
   elastic:


### PR DESCRIPTION
# What:
 - Update the `Hackney.Core.JWT` package multiple versions up _(1.30 -> ... -> 1.87)_.

# Why:
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.

# Notes:
 - The versions in between have no consequence as the only thing the JWT package is used here for is to inject TokenFactory so that logger could use it to extract user email. The Token schema for email hasn't changed. In fact, the only thing that changed about Token schema is Nbf, Exp, and Iat field types being changed from int to long.
 - What changes does latest _(v1.87.0)_ JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.
 - **These changes do not require immediate deployment**, they merely need to be present within the repo's main branch. This is so those changes would already be there for when anyone would introduce new changes attempting to access Google groups from the token. Without this JWT version bump, any attempted access of Groups within the token would make the API wouldn't fall over.
