### PR TITLE
SSI-1110 temporarily remove prod canary

### DIFF
--- a/ReferenceDataApi/serverless.yml
+++ b/ReferenceDataApi/serverless.yml
@@ -52,10 +52,11 @@ functions:
           private: false
 resources:
   Conditions:
-    # Only create the Canary for prod
+    # remove canaries temporarily
     CreateCanary:
       Fn::Equals:
-        - ${self:provider.stage}
+        #- ${self:provider.stage}
+        - "temporarily-disabled"
         - production
   Resources:
     lambdaExecutionRole:


### PR DESCRIPTION
Currently on production we have a mixture of manually and automatically created canaries. This update temporarily removes all configured ones, so we can identify and delete/disable all manually created ones. This will also help to get the CloudFormation stack in sync with the config.

The updated ` Fn::Equals:` always evaluates to false which will cause the canary to be deleted.