### PR TITLE
SSI-1100 Add prod canary

### DIFF
--- a/ReferenceDataApi/serverless.yml
+++ b/ReferenceDataApi/serverless.yml
@@ -52,11 +52,10 @@ functions:
           private: false
 resources:
   Conditions:
-    # remove canaries temporarily
+    # Only create the Canary on prod
     CreateCanary:
       Fn::Equals:
-        #- ${self:provider.stage}
-        - "temporarily-disabled"
+        - ${self:provider.stage}
         - production
   Resources:
     lambdaExecutionRole:
@@ -104,7 +103,7 @@ resources:
       Type: AWS::Synthetics::Canary
       Condition: CreateCanary
       Properties:
-        Name: reference-data-health #Update name accordingly, max 21 characters
+        Name: reference-data-health-2
         Code:
           Handler: pageLoadBlueprint.handler
           S3Bucket: lbh-cw-canaries-api-testing-script-${self:provider.stage}


### PR DESCRIPTION
In #60 the production Canary was temporarily removed to get the CloudFormation stack in sync with the Serverless config and to make it easier to identify manually created resources.

#61 removed the `reference-data-health-new` from the stack, but we still have a stray `reference-data-health` Canary in there. I've used some basic versioning in the name to make it easier to identify what's what. Once deployed I'll stop the `reference-data-health`  from the console.