### PR TITLE
Switch the `production` lambda authorizer to the new one supporting AWS Cognito authentication.

### DIFF
--- a/ReferenceDataApi/serverless.yml
+++ b/ReferenceDataApi/serverless.yml
@@ -135,7 +135,7 @@ custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
-    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-gateway-lambda-authorizer
     pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   safeguards:
     - title: Require authorizer


### PR DESCRIPTION
# What:
 - Switches the legacy authorizer lambda for the new cognito authentication supporting lambda.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `production`.